### PR TITLE
passthru-vendored.nix: add configurePhase to enable compatibility with crane

### DIFF
--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -12,7 +12,7 @@
         bombonVendoredSbom = package.overrideAttrs (previousAttrs: {
           nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ cargo-cyclonedx ];
           outputs = [ "out" ];
-          phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" ];
+          phases = [ "unpackPhase" "patchPhase" "configurePhase" "buildPhase" "installPhase" ];
           buildPhase = ''
             cargo cyclonedx --spec-version 1.4 --format json
           '';


### PR DESCRIPTION
This PR adds compatibility with ["crane"](https://github.com/ipetkov/crane/) by simply adding the `configurePhase` to the `phases` in the vendored passthru for rust packages.

I currently cannot figure out why, but `crane` seems to require this phase to properly vendor all required dependencies into the target directory (even though the `configurePhase` is supposed to be [empty](https://github.com/ipetkov/crane/blob/32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c/lib/mkCargoDerivation.nix#L98)).
EDIT: Maybe it's [this](https://github.com/ipetkov/crane/blob/32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c/lib/setupHooks/configureCargoVendoredDepsHook.sh#L28).

In my surface-level tests this did not break compatibility with other nix build tools such as the standard `buildRustPackage`.