### PR TITLE
flake.nix: add passthruVendoredSbom to flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ You can use the `passthruVendoredSbom.rust` function to add the
 myPackageWithSbom = pkgs.callPackage (bombon.passthruVendoredSbom.rust myPackage) { };
 ```
 
+Or using Flakes:
+
+```nix
+myPackageWithSbom = pkgs.callPackage (bombon.lib.${system}.passthruVendoredSbom.rust myPackage) { };
+```
+
 An SBOM built from this new derivation will now include the vendored dependencies.
 
 ## Options

--- a/flake.nix
+++ b/flake.nix
@@ -58,10 +58,10 @@
     perSystem = { config, system, pkgs, lib, ... }:
       let
         bombon = import ./. { inherit pkgs; };
-        inherit (bombon) transformer buildBom;
+        inherit (bombon) transformer buildBom passthruVendoredSbom;
       in
       {
-        lib = { inherit buildBom; };
+        lib = { inherit buildBom passthruVendoredSbom; };
 
         packages = {
           # This is mostly here for development


### PR DESCRIPTION
This PR simply adds the `passthruVendoredSbom`  functions to `flake.nix`.