### PR TITLE
Only take top-level binary dependencies into account for BOM generation

### DIFF
--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -14,8 +14,9 @@
           nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ pkgs.cargo-cyclonedx ];
           outputs = [ "out" ];
           phases = [ "unpackPhase" "patchPhase" "configurePhase" "buildPhase" "installPhase" ];
+
           buildPhase = ''
-            cargo cyclonedx --spec-version 1.4 --format json --target ${pkgs.stdenv.hostPlatform.rust.rustcTarget} \
+            cargo cyclonedx --spec-version 1.4 --format json --describe binaries --target ${pkgs.stdenv.hostPlatform.rust.rustcTarget} \
           ''
           + pkgs.lib.optionalString
             (builtins.hasAttr "buildNoDefaultFeatures" previousAttrs && previousAttrs.buildNoDefaultFeatures)
@@ -24,10 +25,34 @@
             (builtins.hasAttr "buildFeatures" previousAttrs && builtins.length previousAttrs.buildFeatures > 0)
             (" --features " + builtins.concatStringsSep "," previousAttrs.buildFeatures)
           ;
+
           installPhase = ''
             mkdir -p $out
-            find . -name "*.cdx.json" -execdir install {} $out/{} \;
+
+            # Collect all paths to executable files. Cargo has no good support to find this
+            # and this method is very robust. The flipside is that we have to build the package
+            # to generate a BOM for it.
+            mapfile -d "" binaries < <(find ${package} -type f -executable -print0)
+
+            for binary in "''${binaries[@]}"; do
+              base=$(basename $binary)
+
+              # Strip binary suffixes
+              base=''${base%.exe}
+              base=''${base%.efi}
+
+              cdx=$(find . -name "''${base}_bin.cdx.json")
+
+              if [ -f "$cdx" ]; then
+                echo "Found SBOM for binary '$binary': $cdx"
+                install -m444 "$cdx" $out/
+              else
+                echo "Failed to find SBOM for binary: $binary"
+                exit 1
+              fi
+            done
           '';
+
           separateDebugInfo = false;
         });
       };


### PR DESCRIPTION
The current sbom generation for a rust project like e.g. the cloud hypervisor also contains dependencies that are test or development only. In general, we do not care about those dev dependencies. These dependencies get included because bombon collects the *.cdx.json files in all subfolders and not only of relevant binaries.

A potential fix is to change the cyclone dx invocation to only generate the bom for top-level binaries that will be a result of the rust crate.

This MR is more of a discussion basis and there are some questions to resolve:
* Is this a valid solution?
* Should the behavior be the default or does the user have to configure it?
* What about library crates?

Following is an example bom for the cloud hypervisor project before and after the change:
* [ch-deps-old.json](https://github.com/user-attachments/files/16411468/ch-deps-old.json)
* [ch-deps-new.json](https://github.com/user-attachments/files/16411470/ch-deps-new.json)

@blitz
