### PR TITLE
passthruVendoredSbom.rust: disable build dependencies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ bombon.lib.${system}.buildBom pkgs.hello {
 }
 ```
 
+`passthruVendoredSbom.rust` also accepts `includeBuildtimeDependencies` as an optional attribute.
+
+Example:
+
+```nix
+myPackageWithSbom = bombon.passthruVendoredSbom.rust myPackage { inherit pkgs; includeBuildtimeDependencies = true; };
+```
+
 ## Contributing
 
 During development, the Nix Repl is a convenient and quick way to test changes.

--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722062969,
-        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
+        "lastModified": 1725432240,
+        "narHash": "sha256-+yj+xgsfZaErbfYM3T+QvEE2hU7UuE+Jf0fJCJ8uPS0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
+        "rev": "ad416d066ca1222956472ab7d0555a6946746a80",
         "type": "github"
       },
       "original": {

--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -6,7 +6,7 @@
   # This could be done much more elegantly if `buildRustPackage` supported
   # finalAttrs. When https://github.com/NixOS/nixpkgs/pull/194475 lands, we can
   # most likely get rid of this.
-  rust = package: { pkgs }: package.overrideAttrs
+  rust = package: { pkgs, includeBuildtimeDependencies ? false }: package.overrideAttrs
     (previousAttrs: {
       passthru = (previousAttrs.passthru or { }) // {
         bombonVendoredSbom = package.overrideAttrs (previousAttrs: {
@@ -24,6 +24,7 @@
           + pkgs.lib.optionalString
             (builtins.hasAttr "buildFeatures" previousAttrs && builtins.length previousAttrs.buildFeatures > 0)
             (" --features " + builtins.concatStringsSep "," previousAttrs.buildFeatures)
+          + pkgs.lib.optionalString (!includeBuildtimeDependencies) " --no-build-deps"
           ;
 
           installPhase = ''

--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -11,7 +11,7 @@
       passthru = (previousAttrs.passthru or { }) // {
         bombonVendoredSbom = package.overrideAttrs (previousAttrs: {
           pname = previousAttrs.pname + "-bombon-vendored-sbom";
-          nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ pkgs.cargo-cyclonedx ];
+          nativeBuildInputs = (previousAttrs.nativeBuildInputs or [ ]) ++ [ pkgs.buildPackages.cargo-cyclonedx ];
           outputs = [ "out" ];
           phases = [ "unpackPhase" "patchPhase" "configurePhase" "buildPhase" "installPhase" ];
 


### PR DESCRIPTION
cargo-cyclonedx 0.5.5 supports `--no-build-deps`. Use this to implement the same default behavior as `buildBom`.