### PR TITLE
transformer: handle null in src.url during deserialization

### DIFF
--- a/rust/transformer/src/cyclonedx.rs
+++ b/rust/transformer/src/cyclonedx.rs
@@ -153,7 +153,9 @@ impl CycloneDXComponent {
         let mut external_references = Vec::new();
 
         if let Some(src) = derivation.src {
-            external_references.push(convert_src(&src));
+            if src.url.is_some() {
+                external_references.push(convert_src(&src));
+            }
         }
         if let Some(meta) = derivation.meta {
             component.licenses = convert_licenses(&meta);
@@ -194,9 +196,13 @@ fn convert_licenses(meta: &Meta) -> Option<Licenses> {
 }
 
 fn convert_src(src: &Src) -> ExternalReference {
+    assert!(
+        src.url.is_some(),
+        "src.url must be Some to generate ExternalReference",
+    );
     ExternalReference {
         external_reference_type: ExternalReferenceType::Vcs,
-        url: string_to_url(&src.url),
+        url: string_to_url(&src.url.clone().unwrap_or_default()),
         comment: None,
         hashes: src.hash.clone().and_then(|s| convert_hash(&s)),
     }

--- a/rust/transformer/src/derivation.rs
+++ b/rust/transformer/src/derivation.rs
@@ -73,6 +73,6 @@ pub struct License {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct Src {
-    pub url: String,
+    pub url: Option<String>,
     pub hash: Option<String>,
 }


### PR DESCRIPTION
Turns out that nix can produce a `src` field only containing `"url": null`. This leads to:
```
> Error: Failed to parse buildtime input
>
> Caused by:
>     invalid type: null, expected a string at line 335292 column 17
```