### PR TITLE
WIP: missing VCS urls

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -85,6 +85,12 @@ let
       drv = rustPassthru cloud-hypervisor;
       options = buildtimeOptions;
     }
+
+    # resulted in empty VCS info in the past
+    { name = "kexec-tools";
+      drv = kexec-tools;
+      options = {};
+    }
   ];
 
   cycloneDxVersion = "1.5";
@@ -99,11 +105,12 @@ let
   buildBomAndValidate =
     drv: options:
     pkgs.runCommand "${drv.name}-bom-validation" { nativeBuildInputs = [ pkgs.check-jsonschema ]; } ''
+      BOM="${buildBom drv options}"
       check-jsonschema \
         --schemafile "${cycloneDxSpec}/schema/bom-${cycloneDxVersion}.schema.json" \
         --base-uri "${cycloneDxSpec}/schema/bom-${cycloneDxVersion}.schema.json" \
-        "${buildBom drv options}"
-      touch $out
+        $BOM
+      cp $BOM $out
     '';
 
   genAttrsFromDrvs =

--- a/rust/transformer/src/cyclonedx.rs
+++ b/rust/transformer/src/cyclonedx.rs
@@ -215,6 +215,11 @@ fn convert_src(src: &Src) -> ExternalReference {
         src.url.is_some(),
         "src.url must be Some to generate ExternalReference",
     );
+    println!("Sources: {src:#?}");
+    assert!(
+        !src.url.clone().unwrap().is_empty(),
+        "src.url should not be empty string in order to generate ExternalReference",
+    );
     ExternalReference {
         external_reference_type: ExternalReferenceType::Vcs,
         url: string_to_url(&src.url.clone().unwrap_or_default()),


### PR DESCRIPTION
```
bombon on  mtheil/reproduce-missing-vcs [$] took 1s521ms
at 11:46:16 ❌1 λ nix build .#checks.x86_64-linux.kexec-tools --builders '' -L
kexec-tools> Sources: Src {
kexec-tools>     url: Some(
kexec-tools>         "",
kexec-tools>     ),
kexec-tools>     hash: Some(
kexec-tools>         "sha256-Z7GsUDqt5FpU2wvHkiiogwo11dT4PO6TLP8+eoGkqew=",
kexec-tools>     ),
kexec-tools> }
kexec-tools> thread 'main' panicked at src/cyclonedx.rs:219:5:
kexec-tools> src.url should not be empty string in order to generate ExternalReference
kexec-tools> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: builder for '/nix/store/kyp2xn1v89ik4vlbbkj4h4a4nvim85xq-kexec-tools-2.0.29.cdx.json.drv' failed with exit code 101;
       last 11 log lines:
       > Sources: Src {
       >     url: Some(
       >         "",
       >     ),
       >     hash: Some(
       >         "sha256-Z7GsUDqt5FpU2wvHkiiogwo11dT4PO6TLP8+eoGkqew=",
       >     ),
       > }
       > thread 'main' panicked at src/cyclonedx.rs:219:5:
       > src.url should not be empty string in order to generate ExternalReference
       > note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       For full logs, run 'nix log /nix/store/kyp2xn1v89ik4vlbbkj4h4a4nvim85xq-kexec-tools-2.0.29.cdx.json.drv'.
error: 1 dependencies of derivation '/nix/store/xacj6gbfacwkab0nnxw2vxadrair3p7r-kexec-tools-2.0.29-bom-validation.drv' failed to build
```