### PR TITLE
transformer: include CPE fields from meta, including possibleCPEs as evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added the ability to extract patches from a derivation and include them in
   the SBOM.
 - Added the ability to include multiple source URLs as external references.
+- Added the ability to extract CPEs from Nix packages. "Guessed" CPEs in
+  the `possibleCPEs` field are included as evidence in the SBOM.
 
 ### Fixed
 

--- a/nix/packages/transformer.nix
+++ b/nix/packages/transformer.nix
@@ -44,5 +44,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = licenses.mit;
     maintainers = with lib.maintainers; [ nikstur ];
     mainProgram = "bombon-transformer";
+    identifiers.cpeParts = lib.meta.cpePatchVersionInUpdateWithVendor "nikstur" finalAttrs.version;
   };
 })

--- a/rust/transformer/src/derivation.rs
+++ b/rust/transformer/src/derivation.rs
@@ -41,6 +41,19 @@ pub struct Meta {
     pub license: Option<LicenseField>,
     pub homepage: Option<String>,
     pub description: Option<String>,
+    pub identifiers: Option<Identifiers>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct Identifiers {
+    pub cpe: Option<String>,
+    #[serde(rename = "possibleCPEs")]
+    pub possible_cpes: Option<Vec<Cpe>>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct Cpe {
+    pub cpe: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
This PR implements the inclusion of "CPE" fields in current nixos unstable based on #150.

The CPE fields were implemented by adding an `identifier` field in the `meta` field of derivations. This field can include `cpe` as a "definitive" CPE identifier, as well as `possibleCPEs` as a list of possibly fitting CPE identifiers.

This PR implements the following:

- Update dependencies, especially nixpkgs-unstable.
- Adds `Identifiers`, `CPE` as structs to deserialize the `identifiers` field.
- If `cpe` exists, add `cpe` to the SBOM component. Only one CPE is allowed here in the CycloneDX spec.
- If only `possibleCPEs` exist, add an [`evidence`](https://cyclonedx.org/docs/1.5/json/#components_items_evidence) field to the SBOM, with an entry for each possible CPE. Each entry get's a proportional "Confidence" score, based on the number of `possibleCPEs` in the metadata.

We could make using "evidence" optional.

In an SBOM this would look like:

With a definitive CPE field:

```json
      "cpe": "cpe:2.3:a:nikstur:bombon-transformer:0.3:0:*:*:*:*:*:*",
```

While with evidence:

```json
      "evidence": {
        "identity": {
          "field": "cpe",
          "methods": [
            {
              "technique": "other",
              "confidence": 0.5,
              "value": "cpe:2.3:a:gnu:gcc:14.3.0:*:*:*:*:*:*:*"
            },
            {
              "technique": "other",
              "confidence": 0.5,
              "value": "cpe:2.3:a:gnu:gcc:14.3:0:*:*:*:*:*:*"
            }
          ]
        }
      }
```