### PR TITLE
passthru-vendored: ignore dot-prefixed binaries

### DIFF
--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -49,7 +49,7 @@
             # Collect all paths to executable files. Cargo has no good support to find this
             # and this method is very robust. The flipside is that we have to build the package
             # to generate a BOM for it.
-            mapfile -d "" binaries < <(find ${package} -type f -executable -print0)
+            mapfile -d "" binaries < <(find ${package} -type f ! -name ".*" -executable -print0)
 
             for binary in "''${binaries[@]}"; do
               base=$(basename $binary)


### PR DESCRIPTION
fixes error when building SBOM for rust binaries wrapped with makeBinaryWrapper