### PR TITLE
passthru-vendored: respect cargoRoot

### DIFF
--- a/nix/passthru-vendored.nix
+++ b/nix/passthru-vendored.nix
@@ -29,6 +29,10 @@
           ];
 
           buildPhase = ''
+            if [ -n "''${cargoRoot-}" ]; then
+              cd "$cargoRoot"
+            fi
+
             cargo cyclonedx \
               --spec-version 1.5 \
               --format json \


### PR DESCRIPTION
This is useful for packages with path dependencies.

Uses upstreams cargoRoot attribute, see:
https://github.com/NixOS/nixpkgs/blob/2a04430e5c55a57deb635d1fd33b722b3eccd8bf/pkgs/build-support/rust/fetch-cargo-vendor.nix#L73