### PR TITLE
transformer: Fix CPE by using `cpeFullVersionWithVendor`

### DIFF
--- a/nix/packages/transformer.nix
+++ b/nix/packages/transformer.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = licenses.mit;
     maintainers = with lib.maintainers; [ nikstur ];
     mainProgram = "bombon-transformer";
-    identifiers.cpeParts = lib.meta.cpePatchVersionInUpdateWithVendor "nikstur" finalAttrs.version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "nikstur" finalAttrs.version;
   };
 })


### PR DESCRIPTION
The previously used `cpePatchVersionInUpdateWithVendor` helper produced a technically invalid CPE.

The version number, in whole, must be in the `version` field, according to the *NISTIR 7695* specification for CPE 2.3.

The `update` field is used for a vendor provided string, which would generally be something like `beta`, `rc1`, etc.

While *technically speaking*, this is the vendor producing this CPE, I must assume that the intent is to follow the intent of the spec, which would put the *version number* in the `version` field, and not just a portion of it.

See https://github.com/NixOS/nixpkgs/pull/508061 for more context.

Fixes: d42b699e0d59161f9294e507ea2446aaa4559ce0

* * *

This was verified using:

```
.../bombon $ nix repl -f . --arg pkgs 'import <nixpkgs> {}'
nix-repl> transformer.meta.identifiers
{
  cpe = "cpe:2.3:a:nikstur:bombon-transformer:0.4:0:*:*:*:*:*:*";
  cpeParts = { ... };
  possibleCPEs = [ ... ];
  v1 = { ... };
}

.../bombon $ nix repl -f . --arg pkgs 'import .../nixos-PR-508061 {}'
nix-repl> transformer.meta.identifiers
{
  cpe = "cpe:2.3:a:nikstur:bombon-transformer:0.4.0:*:*:*:*:*:*:*";
  cpeParts = { ... };
  possibleCPEs = [ ... ];
  v1 = { ... };
}
```