### PR TITLE
transformer: emit CycloneDX dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added emitting a CycloneDX dependency graph spanning runtime dependencies,
+  vendored language-level SBOMs' graphs, and optionally build-time dependencies
+  via the `includeBuildtimeDependencies` flag.
 - Added support for compound licenses from Nixpkgs. Compound licenses are now
   included as SPDX expressions in the SBOM.
 - Added support for CycloneDX v1.7.

--- a/nix/buildtime-dependencies.nix
+++ b/nix/buildtime-dependencies.nix
@@ -79,6 +79,8 @@ let
     // {
       path = drv.outPath;
       patches = lib.flatten (drv.patches or [ ]);
+      # The store paths of this derivation's direct build-time dependencies, so the transformer can emit build-time `dependsOn` edges.
+      buildReferences = lib.unique (map (o: o.outPath) (lib.concatLists (drvDeps drv)));
     }
     // lib.optionalAttrs (drv ? src && drv.src ? urls) {
       src = {

--- a/nix/runtime-dependencies.nix
+++ b/nix/runtime-dependencies.nix
@@ -1,11 +1,19 @@
-# This is a wrapper around nixpkgs' closureInfo. It returns a newline
-# separated list of the store paths of drv's runtime dependencies.
+# This returns a list of the store paths of drv's runtime dependencies.
+# The additionally emitted `references` are the direct runtime references of `path`,
+# needed to emit a CycloneDX `dependencies` graph.
 {
   runCommand,
-  closureInfo,
+  jq,
 }:
 
 drv: extraPaths:
-runCommand "${drv.name}-runtime-dependencies.txt" { } ''
-  cat ${closureInfo { rootPaths = [ drv ] ++ extraPaths; }}/store-paths > $out
-''
+runCommand "${drv.name}-runtime-dependencies.json"
+  {
+    __structuredAttrs = true;
+    exportReferencesGraph.closure = [ drv ] ++ extraPaths;
+    nativeBuildInputs = [ jq ];
+  }
+  ''
+    jq '[.closure[] | { path: .path, references: .references }]' \
+      "$NIX_ATTRS_JSON_FILE" > "$out"
+  ''

--- a/rust/transformer/src/cyclonedx.rs
+++ b/rust/transformer/src/cyclonedx.rs
@@ -15,6 +15,7 @@ use cyclonedx_bom::models::component::{Classification, Component, Components, Cp
 use cyclonedx_bom::models::component::{
     ComponentEvidence, ConfidenceScore, Identity, IdentityField, Method, Methods, Pedigree,
 };
+use cyclonedx_bom::models::dependency::{Dependencies, Dependency};
 use cyclonedx_bom::models::external_reference::{
     self, ExternalReference, ExternalReferenceType, ExternalReferences,
 };
@@ -46,19 +47,21 @@ impl CycloneDXBom {
         Ok(Self(Bom::parse_from_json(file)?))
     }
 
-    pub fn build(target: Derivation, components: CycloneDXComponents, output: &Path) -> Self {
+    pub fn build(
+        target: Derivation,
+        components: CycloneDXComponents,
+        dependencies: Dependencies,
+        output: &Path,
+    ) -> Self {
         Self(Bom {
             components: Some(components.into()),
+            dependencies: (!dependencies.0.is_empty()).then_some(dependencies),
             metadata: Some(metadata_from_derivation(target)),
             // Derive a reproducible serial number from the output path. This works because the Nix
             // outPath of the derivation is input addressed and thus reproducible.
             serial_number: Some(derive_serial_number(output.as_os_str().as_encoded_bytes())),
             ..Bom::default()
         })
-    }
-
-    fn components(self) -> Option<Components> {
-        self.0.components
     }
 }
 
@@ -91,8 +94,20 @@ impl CycloneDXComponents {
     }
 
     /// Extend the `Components` with components read from multiple BOMs inside a directory.
-    pub fn extend_from_directory(&mut self, path: impl AsRef<Path>) -> Result<()> {
+    ///
+    /// Returns the `dependencies` graphs declared by those BOMs, so the (language-level)
+    /// edges they carry can be preserved in the aggregate SBOM.
+    ///
+    /// Each vendored BOM's root (`metadata.component`) describes the same artifact as the owning Nix derivation,
+    /// but is never itself emitted as a component. Its bom-ref is therefore remapped to `target_ref` so the
+    /// language-level graph connects to the store-path component instead of dangling on a root that nothing references.
+    pub fn extend_from_directory(
+        &mut self,
+        path: impl AsRef<Path>,
+        target_ref: &str,
+    ) -> Result<Vec<Dependency>> {
         let mut m = BTreeMap::new();
+        let mut dependencies = Vec::new();
 
         // Insert the components from the original SBOM
         for component in self.0.0.clone() {
@@ -109,19 +124,50 @@ impl CycloneDXComponents {
             .flatten()
         {
             let bom = CycloneDXBom::from_file(entry.path())?;
-            if let Some(components) = bom.components() {
-                for component in components.0 {
+            let root_ref = bom
+                .0
+                .metadata
+                .as_ref()
+                .and_then(|meta| meta.component.as_ref())
+                .and_then(|component| component.bom_ref.clone());
+            if let Some(components) = &bom.0.components {
+                for component in &components.0 {
                     let key = component
                         .bom_ref
                         .clone()
                         .unwrap_or_else(|| component.name.to_string());
-                    m.entry(key).or_insert(component);
+                    m.entry(key).or_insert_with(|| component.clone());
+                }
+            }
+            if let Some(deps) = bom.0.dependencies {
+                for mut dep in deps.0 {
+                    if let Some(root) = &root_ref {
+                        if dep.dependency_ref == *root {
+                            dep.dependency_ref = target_ref.to_string();
+                        }
+                        for sub in &mut dep.dependencies {
+                            if sub == root {
+                                *sub = target_ref.to_string();
+                            }
+                        }
+                    }
+                    dependencies.push(dep);
                 }
             }
         }
 
         self.0.0 = m.into_values().collect();
-        Ok(())
+        Ok(dependencies)
+    }
+
+    /// The set of references of the components currently held.
+    /// Keeps the dependency graph valid: edges to/from absent components are dropped.
+    pub fn bom_refs(&self) -> std::collections::BTreeSet<String> {
+        self.0
+            .0
+            .iter()
+            .map(|c| c.bom_ref.clone().unwrap_or_else(|| c.name.to_string()))
+            .collect()
     }
 
     // Deduplicate components.

--- a/rust/transformer/src/cyclonedx.rs
+++ b/rust/transformer/src/cyclonedx.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Into;
 use std::fs;
 use std::path::Path;
@@ -26,8 +26,18 @@ use cyclonedx_bom::models::tool::Tools;
 use itertools::Itertools;
 use sha2::{Digest, Sha256};
 
+use crate::buildtime_input::BuildtimeInput;
 use crate::derivation::{self, Derivation, Meta, Src};
 use crate::hash::{self, SriHash};
+use crate::runtime_input::RuntimeInput;
+
+/// Strip the `/nix/store/` prefix to match how component bom-refs are derived from store paths.
+fn bom_ref(store_path: &str) -> String {
+    store_path
+        .strip_prefix("/nix/store/")
+        .unwrap_or(store_path)
+        .to_string()
+}
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -50,12 +60,12 @@ impl CycloneDXBom {
     pub fn build(
         target: Derivation,
         components: CycloneDXComponents,
-        dependencies: Dependencies,
+        dependencies: CycloneDXDependencies,
         output: &Path,
     ) -> Self {
         Self(Bom {
             components: Some(components.into()),
-            dependencies: (!dependencies.0.is_empty()).then_some(dependencies),
+            dependencies: (!dependencies.0.0.is_empty()).then_some(dependencies.0),
             metadata: Some(metadata_from_derivation(target)),
             // Derive a reproducible serial number from the output path. This works because the Nix
             // outPath of the derivation is input addressed and thus reproducible.
@@ -99,13 +109,14 @@ impl CycloneDXComponents {
     /// edges they carry can be preserved in the aggregate SBOM.
     ///
     /// Each vendored BOM's root (`metadata.component`) describes the same artifact as the owning Nix derivation,
-    /// but is never itself emitted as a component. Its bom-ref is therefore remapped to `target_ref` so the
-    /// language-level graph connects to the store-path component instead of dangling on a root that nothing references.
+    /// but is never itself emitted as a component. Its bom-ref is therefore remapped to the owning derivation's
+    /// bom-ref so the language-level graph connects to the store-path component instead of dangling on a root that nothing references.
     pub fn extend_from_directory(
         &mut self,
         path: impl AsRef<Path>,
-        target_ref: &str,
-    ) -> Result<Vec<Dependency>> {
+        owner_path: &str,
+    ) -> Result<VendoredDependencies> {
+        let target_ref = bom_ref(owner_path);
         let mut m = BTreeMap::new();
         let mut dependencies = Vec::new();
 
@@ -143,11 +154,11 @@ impl CycloneDXComponents {
                 for mut dep in deps.0 {
                     if let Some(root) = &root_ref {
                         if dep.dependency_ref == *root {
-                            dep.dependency_ref = target_ref.to_string();
+                            dep.dependency_ref.clone_from(&target_ref);
                         }
                         for sub in &mut dep.dependencies {
                             if sub == root {
-                                *sub = target_ref.to_string();
+                                sub.clone_from(&target_ref);
                             }
                         }
                     }
@@ -157,12 +168,12 @@ impl CycloneDXComponents {
         }
 
         self.0.0 = m.into_values().collect();
-        Ok(dependencies)
+        Ok(VendoredDependencies(dependencies))
     }
 
     /// The set of references of the components currently held.
     /// Keeps the dependency graph valid: edges to/from absent components are dropped.
-    pub fn bom_refs(&self) -> std::collections::BTreeSet<String> {
+    pub fn bom_refs(&self) -> BTreeSet<String> {
         self.0
             .0
             .iter()
@@ -196,6 +207,104 @@ impl From<CycloneDXComponents> for Components {
     }
 }
 
+/// The (language-level) dependency edges carried by vendored SBOMs, before they are
+/// reconciled against the components that actually end up in the final BOM.
+#[derive(Default)]
+pub struct VendoredDependencies(Vec<Dependency>);
+
+impl VendoredDependencies {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Merge in the edges from another set of vendored dependencies.
+    pub fn extend(&mut self, other: VendoredDependencies) {
+        self.0.extend(other.0);
+    }
+}
+
+pub struct CycloneDXDependencies(Dependencies);
+
+impl CycloneDXDependencies {
+    /// Assemble the `CycloneDX` dependency graph. Three sources of edges are combined:
+    ///   - the Nix runtime reference graph (from `exportReferencesGraph`), keyed by store path
+    ///   - the Nix build-time reference graph (each derivation's direct build inputs)
+    ///   - the language-level graphs carried by the vendored SBOMs, keyed by purl
+    ///
+    /// Edges are restricted to refs that actually exist in the final BOM, so the graph stays
+    /// valid after filtering and deduplication. Entries are merged by ref so no `dependency_ref`
+    /// appears twice.
+    pub fn assemble(
+        components: &CycloneDXComponents,
+        target_derivation: &Derivation,
+        runtime_input: &RuntimeInput,
+        buildtime_input: &BuildtimeInput,
+        include_buildtime_dependencies: bool,
+        vendored_dependencies: VendoredDependencies,
+    ) -> Self {
+        let mut present = components.bom_refs();
+        present.insert(bom_ref(&target_derivation.path));
+
+        let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for (path, references) in &runtime_input.references {
+            let dependent = bom_ref(path);
+            if !present.contains(&dependent) {
+                continue;
+            }
+            let entry = graph.entry(dependent).or_default();
+            for reference in references {
+                let dependency = bom_ref(reference);
+                if present.contains(&dependency) {
+                    entry.insert(dependency);
+                }
+            }
+        }
+        if include_buildtime_dependencies {
+            for derivation in buildtime_input.0.values() {
+                let dependent = bom_ref(&derivation.path);
+                if !present.contains(&dependent) {
+                    continue;
+                }
+                let entry = graph.entry(dependent.clone()).or_default();
+                for reference in &derivation.build_references {
+                    let dependency = bom_ref(reference);
+                    if dependency != dependent && present.contains(&dependency) {
+                        entry.insert(dependency);
+                    }
+                }
+            }
+        }
+        for dependency in vendored_dependencies.0 {
+            if !present.contains(&dependency.dependency_ref) {
+                continue;
+            }
+            let entry = graph.entry(dependency.dependency_ref).or_default();
+            for sub in dependency.dependencies {
+                if present.contains(&sub) {
+                    entry.insert(sub);
+                }
+            }
+        }
+
+        // Declare every component as a node, including leaves with no dependencies of
+        // their own: the CycloneDX spec (as required by BSI TR-03183-2 §5.1) mandates
+        // that such components appear as empty elements in the dependency graph.
+        for reference in &present {
+            graph.entry(reference.clone()).or_default();
+        }
+
+        Self(Dependencies(
+            graph
+                .into_iter()
+                .map(|(dependency_ref, dependencies)| Dependency {
+                    dependency_ref,
+                    dependencies: dependencies.into_iter().collect(),
+                })
+                .collect(),
+        ))
+    }
+}
+
 struct CycloneDXComponent(Component);
 
 impl CycloneDXComponent {
@@ -211,13 +320,7 @@ impl CycloneDXComponent {
             Classification::Application,
             &name,
             &version,
-            Some(
-                derivation
-                    .path
-                    .strip_prefix("/nix/store/")
-                    .unwrap_or(&derivation.path)
-                    .to_string(),
-            ),
+            Some(bom_ref(&derivation.path)),
         );
         component.scope = Some(Scope::Required);
         component.purl = Purl::new("nix", &name, &version).ok();

--- a/rust/transformer/src/derivation.rs
+++ b/rust/transformer/src/derivation.rs
@@ -13,6 +13,8 @@ pub struct Derivation {
     pub src: Option<Src>,
     pub vendored_sbom: Option<String>,
     pub patches: Vec<String>,
+    #[serde(default)]
+    pub build_references: Vec<String>,
 }
 
 impl Derivation {

--- a/rust/transformer/src/runtime_input.rs
+++ b/rust/transformer/src/runtime_input.rs
@@ -1,17 +1,41 @@
-use std::borrow::ToOwned;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Deserialize;
 
-pub struct RuntimeInput(pub BTreeSet<String>);
+#[derive(Deserialize)]
+struct ClosureEntry {
+    path: String,
+    references: Vec<String>,
+}
+
+pub struct RuntimeInput {
+    /// The set of store paths in the runtime closure.
+    pub paths: BTreeSet<String>,
+    /// For each store path, its direct runtime references (self-references removed).
+    pub references: BTreeMap<String, Vec<String>>,
+}
 
 impl RuntimeInput {
     pub fn from_file(path: &Path) -> Result<Self> {
-        let file_content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
-        let set: BTreeSet<String> = file_content.lines().map(ToOwned::to_owned).collect();
-        Ok(Self(set))
+        let entries: Vec<ClosureEntry> = serde_json::from_reader(
+            fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?,
+        )
+        .with_context(|| format!("Failed to parse runtime input at {}", path.display()))?;
+
+        let mut paths = BTreeSet::new();
+        let mut references = BTreeMap::new();
+        for entry in entries {
+            let refs: Vec<String> = entry
+                .references
+                .into_iter()
+                .filter(|r| r != &entry.path)
+                .collect();
+            paths.insert(entry.path.clone());
+            references.insert(entry.path, refs);
+        }
+        Ok(Self { paths, references })
     }
 }

--- a/rust/transformer/src/runtime_input.rs
+++ b/rust/transformer/src/runtime_input.rs
@@ -20,10 +20,10 @@ pub struct RuntimeInput {
 
 impl RuntimeInput {
     pub fn from_file(path: &Path) -> Result<Self> {
-        let entries: Vec<ClosureEntry> = serde_json::from_reader(
-            fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?,
-        )
-        .with_context(|| format!("Failed to parse runtime input at {}", path.display()))?;
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let entries: Vec<ClosureEntry> = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse runtime input at {}", path.display()))?;
 
         let mut paths = BTreeSet::new();
         let mut references = BTreeMap::new();

--- a/rust/transformer/src/transform.rs
+++ b/rust/transformer/src/transform.rs
@@ -1,25 +1,17 @@
-use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use cyclonedx_bom::models::dependency::{Dependencies, Dependency};
 use itertools::Itertools;
 use regex::RegexSet;
 
 use crate::buildtime_input::BuildtimeInput;
-use crate::cyclonedx::{CycloneDXBom, CycloneDXComponents};
+use crate::cyclonedx::{
+    CycloneDXBom, CycloneDXComponents, CycloneDXDependencies, VendoredDependencies,
+};
 use crate::derivation::Derivation;
 use crate::runtime_input::RuntimeInput;
-
-/// Strip the `/nix/store/` prefix to match how component bom-refs are derived from store paths.
-fn bom_ref(store_path: &str) -> String {
-    store_path
-        .strip_prefix("/nix/store/")
-        .unwrap_or(store_path)
-        .to_string()
-}
 
 pub fn transform(
     include_buildtime_dependencies: bool,
@@ -86,17 +78,17 @@ pub fn transform(
 
     // Augment the components with those retrieved from the `sbom` passthru attribute of the
     // derivations, preserving the (language-level) dependency edges those SBOMs declare.
-    let mut vendored_dependencies = Vec::new();
+    let mut vendored_dependencies = VendoredDependencies::new();
     for derivation in buildtime_input.0.values() {
         if let Some(sbom_path) = &derivation.vendored_sbom {
-            let target_ref = bom_ref(&derivation.path);
-            vendored_dependencies.extend(components.extend_from_directory(sbom_path, &target_ref)?);
+            vendored_dependencies
+                .extend(components.extend_from_directory(sbom_path, &derivation.path)?);
         }
     }
 
     components.deduplicate();
 
-    let dependencies = assemble_dependencies(
+    let dependencies = CycloneDXDependencies::assemble(
         &components,
         &target_derivation,
         &runtime_input,
@@ -111,80 +103,4 @@ pub fn transform(
     file.write_all(&bom.serialize()?)?;
 
     Ok(())
-}
-
-// Assemble the CycloneDX dependency graph. Three sources of edges are combined:
-//   - the Nix runtime reference graph (from exportReferencesGraph), keyed by store path
-//   - the Nix build-time reference graph (each derivation's direct build inputs)
-//   - the language-level graphs carried by the vendored SBOMs, keyed by purl
-// Edges are restricted to refs that actually exist in the final BOM, so the graph stays
-// valid after filtering and deduplication. Entries are merged by ref so no dependency_ref appears twice.
-fn assemble_dependencies(
-    components: &CycloneDXComponents,
-    target_derivation: &Derivation,
-    runtime_input: &RuntimeInput,
-    buildtime_input: &BuildtimeInput,
-    include_buildtime_dependencies: bool,
-    vendored_dependencies: Vec<Dependency>,
-) -> Dependencies {
-    let mut present = components.bom_refs();
-    present.insert(bom_ref(&target_derivation.path));
-
-    let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-    for (path, references) in &runtime_input.references {
-        let dependent = bom_ref(path);
-        if !present.contains(&dependent) {
-            continue;
-        }
-        let entry = graph.entry(dependent).or_default();
-        for reference in references {
-            let dependency = bom_ref(reference);
-            if present.contains(&dependency) {
-                entry.insert(dependency);
-            }
-        }
-    }
-    if include_buildtime_dependencies {
-        for derivation in buildtime_input.0.values() {
-            let dependent = bom_ref(&derivation.path);
-            if !present.contains(&dependent) {
-                continue;
-            }
-            let entry = graph.entry(dependent.clone()).or_default();
-            for reference in &derivation.build_references {
-                let dependency = bom_ref(reference);
-                if dependency != dependent && present.contains(&dependency) {
-                    entry.insert(dependency);
-                }
-            }
-        }
-    }
-    for dependency in vendored_dependencies {
-        if !present.contains(&dependency.dependency_ref) {
-            continue;
-        }
-        let entry = graph.entry(dependency.dependency_ref).or_default();
-        for sub in dependency.dependencies {
-            if present.contains(&sub) {
-                entry.insert(sub);
-            }
-        }
-    }
-
-    // Declare every component as a node, including leaves with no dependencies of
-    // their own: the CycloneDX spec (as required by BSI TR-03183-2 §5.1) mandates
-    // that such components appear as empty elements in the dependency graph.
-    for reference in &present {
-        graph.entry(reference.clone()).or_default();
-    }
-
-    Dependencies(
-        graph
-            .into_iter()
-            .map(|(dependency_ref, dependencies)| Dependency {
-                dependency_ref,
-                dependencies: dependencies.into_iter().collect(),
-            })
-            .collect(),
-    )
 }

--- a/rust/transformer/src/transform.rs
+++ b/rust/transformer/src/transform.rs
@@ -1,8 +1,10 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use cyclonedx_bom::models::dependency::{Dependencies, Dependency};
 use itertools::Itertools;
 use regex::RegexSet;
 
@@ -10,6 +12,14 @@ use crate::buildtime_input::BuildtimeInput;
 use crate::cyclonedx::{CycloneDXBom, CycloneDXComponents};
 use crate::derivation::Derivation;
 use crate::runtime_input::RuntimeInput;
+
+/// Strip the `/nix/store/` prefix to match how component bom-refs are derived from store paths.
+fn bom_ref(store_path: &str) -> String {
+    store_path
+        .strip_prefix("/nix/store/")
+        .unwrap_or(store_path)
+        .to_string()
+}
 
 pub fn transform(
     include_buildtime_dependencies: bool,
@@ -33,7 +43,7 @@ pub fn transform(
     // Augment the runtime input with information from the buildtime input. The buildtime input,
     // however, is not a strict superset of the runtime input. This has to do with how we query the
     // buildinputs from Nix and how dependencies can "hide" in String Contexts.
-    let runtime_derivations = runtime_input.0.iter().map(|store_path| {
+    let runtime_derivations = runtime_input.paths.iter().map(|store_path| {
         buildtime_input
             .0
             .get(store_path)
@@ -45,7 +55,7 @@ pub fn transform(
         .0
         .clone()
         .into_values()
-        .filter(|derivation| !runtime_input.0.contains(&derivation.path))
+        .filter(|derivation| !runtime_input.paths.contains(&derivation.path))
         .unique_by(|d| d.name.clone().unwrap_or(d.path.clone()));
 
     let all_derivations: Box<dyn Iterator<Item = Derivation>> = if include_buildtime_dependencies {
@@ -75,19 +85,106 @@ pub fn transform(
     let mut components = CycloneDXComponents::from_derivations(all_derivations);
 
     // Augment the components with those retrieved from the `sbom` passthru attribute of the
-    // derivations.
+    // derivations, preserving the (language-level) dependency edges those SBOMs declare.
+    let mut vendored_dependencies = Vec::new();
     for derivation in buildtime_input.0.values() {
         if let Some(sbom_path) = &derivation.vendored_sbom {
-            components.extend_from_directory(sbom_path)?;
+            let target_ref = bom_ref(&derivation.path);
+            vendored_dependencies.extend(components.extend_from_directory(sbom_path, &target_ref)?);
         }
     }
 
     components.deduplicate();
 
-    let bom = CycloneDXBom::build(target_derivation, components, output);
+    let dependencies = assemble_dependencies(
+        &components,
+        &target_derivation,
+        &runtime_input,
+        &buildtime_input,
+        include_buildtime_dependencies,
+        vendored_dependencies,
+    );
+
+    let bom = CycloneDXBom::build(target_derivation, components, dependencies, output);
     let mut file = File::create(output)
         .with_context(|| format!("Failed to create file {}", output.display()))?;
     file.write_all(&bom.serialize()?)?;
 
     Ok(())
+}
+
+// Assemble the CycloneDX dependency graph. Three sources of edges are combined:
+//   - the Nix runtime reference graph (from exportReferencesGraph), keyed by store path
+//   - the Nix build-time reference graph (each derivation's direct build inputs)
+//   - the language-level graphs carried by the vendored SBOMs, keyed by purl
+// Edges are restricted to refs that actually exist in the final BOM, so the graph stays
+// valid after filtering and deduplication. Entries are merged by ref so no dependency_ref appears twice.
+fn assemble_dependencies(
+    components: &CycloneDXComponents,
+    target_derivation: &Derivation,
+    runtime_input: &RuntimeInput,
+    buildtime_input: &BuildtimeInput,
+    include_buildtime_dependencies: bool,
+    vendored_dependencies: Vec<Dependency>,
+) -> Dependencies {
+    let mut present = components.bom_refs();
+    present.insert(bom_ref(&target_derivation.path));
+
+    let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (path, references) in &runtime_input.references {
+        let dependent = bom_ref(path);
+        if !present.contains(&dependent) {
+            continue;
+        }
+        let entry = graph.entry(dependent).or_default();
+        for reference in references {
+            let dependency = bom_ref(reference);
+            if present.contains(&dependency) {
+                entry.insert(dependency);
+            }
+        }
+    }
+    if include_buildtime_dependencies {
+        for derivation in buildtime_input.0.values() {
+            let dependent = bom_ref(&derivation.path);
+            if !present.contains(&dependent) {
+                continue;
+            }
+            let entry = graph.entry(dependent.clone()).or_default();
+            for reference in &derivation.build_references {
+                let dependency = bom_ref(reference);
+                if dependency != dependent && present.contains(&dependency) {
+                    entry.insert(dependency);
+                }
+            }
+        }
+    }
+    for dependency in vendored_dependencies {
+        if !present.contains(&dependency.dependency_ref) {
+            continue;
+        }
+        let entry = graph.entry(dependency.dependency_ref).or_default();
+        for sub in dependency.dependencies {
+            if present.contains(&sub) {
+                entry.insert(sub);
+            }
+        }
+    }
+
+    // Declare every component as a node, including leaves with no dependencies of
+    // their own: the CycloneDX spec (as required by BSI TR-03183-2 §5.1) mandates
+    // that such components appear as empty elements in the dependency graph.
+    for reference in &present {
+        graph.entry(reference.clone()).or_default();
+    }
+
+    Dependencies(
+        graph
+            .into_iter()
+            .map(|(dependency_ref, dependencies)| Dependency {
+                dependency_ref,
+                dependencies: dependencies.into_iter().collect(),
+            })
+            .collect(),
+    )
 }


### PR DESCRIPTION
Fixes #155, plus additionally includes edges for vendored language-level SBOMs. 

bombon currently emits a flat list of components with no `dependencies` graph. This adds one, assembled from two sources:

  - nix runtime references: `runtime-dependencies.nix` now uses `exportReferencesGraph` to capture each store path's direct references
  - vendored SBOMs: the `dependencies` declared by merged-in vendored SBOMs are preserved instead of being dropped when only their components are kept