### PR TITLE
transformer: add `bsi:component:executable` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added a `bsi:component:executable` property to each component, following the
+  BSI TR-03183-2 taxonomy. A component whose derivation sets `meta.mainProgram`
+  is marked `executable`, every other store path `non-executable`.
 - Added support for compound licenses from Nixpkgs. Compound licenses are now
   included as SPDX expressions in the SBOM.
 - Added support for CycloneDX v1.7.

--- a/rust/transformer/src/cyclonedx.rs
+++ b/rust/transformer/src/cyclonedx.rs
@@ -21,6 +21,7 @@ use cyclonedx_bom::models::external_reference::{
 use cyclonedx_bom::models::hash::{Hash, HashAlgorithm, HashValue, Hashes};
 use cyclonedx_bom::models::license::{License, LicenseChoice, Licenses};
 use cyclonedx_bom::models::metadata::Metadata;
+use cyclonedx_bom::models::property::{Properties, Property};
 use cyclonedx_bom::models::tool::Tools;
 use itertools::Itertools;
 use sha2::{Digest, Sha256};
@@ -178,6 +179,23 @@ impl CycloneDXComponent {
         component.hashes = derivation.output_hash.and_then(|s| convert_hash(&s));
 
         let mut external_references = Vec::new();
+
+        // A component that ships a main program is treated as executable; every other store path as non-executable.
+        // Emitted for every component, as the BSI TR-03183-2 taxonomy requires it to occur exactly once.
+        let executable = if derivation
+            .meta
+            .as_ref()
+            .and_then(|m| m.main_program.as_ref())
+            .is_some()
+        {
+            "executable"
+        } else {
+            "non-executable"
+        };
+        component.properties = Some(Properties(vec![Property::new(
+            "bsi:component:executable",
+            executable,
+        )]));
 
         if let Some(src) = derivation.src
             && !src.urls.is_empty()

--- a/rust/transformer/src/derivation.rs
+++ b/rust/transformer/src/derivation.rs
@@ -52,6 +52,8 @@ pub struct Meta {
     pub homepage: Option<String>,
     pub description: Option<String>,
     pub identifiers: Option<Identifiers>,
+    #[serde(rename = "mainProgram")]
+    pub main_program: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug, Default)]


### PR DESCRIPTION
The `bsi:component:executable` property is mandatory according to the [BSI spec](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.pdf?__blob=publicationFile&v=5#%5B%7B%22num%22%3A23%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C54%2C785%2C0%5D).

Unfortunately, not every nix package has set a `meta.mainProgram`, but it's still the best approximation I could come up with.