### PR TITLE
Safeguard license parsing against missing SPDX attributes in SBOM generation

### DIFF
--- a/nix/buildtime-dependencies.nix
+++ b/nix/buildtime-dependencies.nix
@@ -62,10 +62,21 @@ let
   fields =
     drv:
     let
+      # A derivation whose `meta.license` is a hand-rolled attrset or a plain string
+      # does not carry `licenseType`, so `lib.licenses.toSPDX` throws
+      # `attribute 'licenseType' missing` and aborts the entire SBOM. Guard the call.
+      toSPDX =
+        license:
+        if license ? licenseType then
+          lib.licenses.toSPDX license
+        else if lib.isString license then
+          license
+        else
+          "LicenseRef-unknown";
+
       meta = lib.recursiveUpdate drv.meta (
         lib.optionalAttrs (drv.meta ? license) {
-          license =
-            if !(lib.isList drv.meta.license) then lib.licenses.toSPDX drv.meta.license else drv.meta.license;
+          license = if !(lib.isList drv.meta.license) then toSPDX drv.meta.license else drv.meta.license;
         }
       );
     in


### PR DESCRIPTION
I found some issues with custom licences, where bombon crashes. Here I am trying to do a best effort parsing of licences.

Handle non-standard license attributes and plain strings to prevent the SBOM generation from crashing with "attribute 'licenseType' missing". Non-standard licenses now fall back to their SPDX ID, short name, or the string itself.