### PR TITLE
Use a scope for overridability

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,25 +1,20 @@
 { pkgs }:
-
-let
+pkgs.lib.makeScope pkgs.newScope (self: {
   passthruVendoredSbom = import ./nix/passthru-vendored.nix;
-  transformerWithoutSbom = pkgs.callPackage ./nix/packages/transformer.nix { };
-in
-rec {
 
   # It's useful to have these exposed for debugging. However, they are not a
   # public interface.
   __internal = {
-    buildtimeDependencies = pkgs.callPackage ./nix/buildtime-dependencies.nix { };
-    runtimeDependencies = pkgs.callPackage ./nix/runtime-dependencies.nix { };
+    buildtimeDependencies = self.callPackage ./nix/buildtime-dependencies.nix { };
+    runtimeDependencies = self.callPackage ./nix/runtime-dependencies.nix { };
+    transformerWithoutSbom = self.callPackage ./nix/packages/transformer.nix { };
   };
 
-  transformer = passthruVendoredSbom.rust transformerWithoutSbom { inherit pkgs; };
-
-  buildBom = pkgs.callPackage ./nix/build-bom.nix {
-    inherit transformer;
-    inherit (__internal) buildtimeDependencies runtimeDependencies;
+  transformer = self.passthruVendoredSbom.rust self.__internal.transformerWithoutSbom {
+    inherit pkgs;
   };
 
-  inherit passthruVendoredSbom;
-
-}
+  buildBom = self.callPackage ./nix/build-bom.nix {
+    inherit (self.__internal) buildtimeDependencies runtimeDependencies;
+  };
+})


### PR DESCRIPTION
Hello! Its currently very difficult to change bombon's behavior without using forks, or patching inline and causing IFDs; using a scope would allow users to change parts of the library without having to dive too much into the package's internals.